### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Website for analyzing SEO, carbon footprint, UU etc of other websites
 
 This project will use Sanity.io as a CMS, go to the [Sanity documentation to learn more](https://www.sanity.io/docs/sanity-studio)
 
-To install the [Sanity CLI](https://www.sanity.io/docs/getting-started-with-sanity-cli) on your machine, run `npm install -g @sanity/cli` to install the 
+To install the [Sanity CLI](https://www.sanity.io/docs/getting-started-with-sanity-cli) on your machine, run `npm install -g @sanity/cli`.
 
-Navigate to the `studio` folder and run `sanity login` if you have not logged in and then run `sanity start`. 
+Navigate to the `studio` folder and run `sanity login` if you have not logged in and then run `sanity start`. If that doesn't work, you might have to run 'sanity install' first to fetch project-specific commands.
 
 Go to `localhost:3333` to see the local build of the Sanity Studio
 


### PR DESCRIPTION
Fikk denne error-en hos meg før jeg kjørte 'sanity install' i studio mappen:

Error: Command "start" is not available outside of a Sanity project context.
Run the command again within a Sanity project directory, where "@sanity/core"
is installed as a dependency.
    at _.runCommand (~/.nvm/versions/node/v16.13.0/lib/node_modules/@sanity/cli/bin/sanity-cli.js:3608:1340)
    at t.exports (~/.nvm/versions/node/v16.13.0/lib/node_modules/@sanity/cli/bin/sanity-cli.js:1980:2422)